### PR TITLE
Rename package variable to avoid clash with reserved word

### DIFF
--- a/populateHosts.js
+++ b/populateHosts.js
@@ -5,9 +5,9 @@ const fs = require("fs");
 const HOSTS = process.env.SITE_HOSTS.split(",");
 
 let manifest = JSON.parse(fs.readFileSync("./manifest.json"));
-let package = JSON.parse(fs.readFileSync("./package.json"));
+let pack = JSON.parse(fs.readFileSync("./package.json"));
 
-manifest.version = package.version;
+manifest.version = pack.version;
 manifest.update_url = process.env.EXTENSION_UPDATE_URL;
 manifest.permissions = HOSTS;
 manifest.content_scripts = manifest.content_scripts.map(item => Object.assign({}, item, {


### PR DESCRIPTION
Fix https://github.com/Capgemini/dtx-polyfiller/issues/4